### PR TITLE
Get the collation coderef from the correct place.

### DIFF
--- a/lib/MyCPAN/Indexer/Interface/Text.pm
+++ b/lib/MyCPAN/Indexer/Interface/Text.pm
@@ -108,7 +108,8 @@ sub do_interface
 		}
 	print "\n";
 
-	my $collator = $self->get_coordinator->get_note( 'collator' );
+	my $collator_type = $self->get_coordinator->get_component( 'indexer' )->collator_type;
+	my $collator = $self->get_coordinator->get_note( $collator_type );
 	$collator->() if ref $collator eq ref sub {};
 	}
 


### PR DESCRIPTION
Unfortunately, the collator coderef is not stored in the 'collator' key of
the notes reference, but the key whose name is returned from the
collator_type method.

Accessing that method via the indexer as the collator class from
MyCPAN::App::DPAN does not consume the role providing that method
(MyCPAN::Indexer::Component)